### PR TITLE
docs: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ Acknowledgments:
 ## Communication
 
 If you have any questions, please open an issue or join [Discord](https://discord.gg/ukC8KTrRXv).
+
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=vulhub/java-chains&type=Date)](https://star-history.dera.page/#vulhub/java-chains&Date)

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -113,3 +113,7 @@ java -jar java-chains.jar
 ## 交流
 
 有问题请开 Issue，或加入 [Discord](https://discord.gg/ukC8KTrRXv)。
+
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=vulhub/java-chains&type=Date)](https://star-history.dera.page/#vulhub/java-chains&Date)


### PR DESCRIPTION
The star history chart in the README stopped working: the underlying provider is broken due to GitHub stargazer API restrictions, and the chart itself was removed entirely when the docs were reorganized in 3df7b46. A chart that displays project growth is useful to keep around, so this restores it at its original location for both the English and Simplified Chinese READMEs, pointing at the working star-history.dera.page provider. Fixes the missing and unusable star history chart.